### PR TITLE
Fixes verifyAuth

### DIFF
--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -111,7 +111,7 @@ const selfDataController = async (
   req: express.Request,
   res: express.Response
 ) => {
-  return req.body.user;
+  return res.status(200).send({ user: req.body.user });
 };
 
 export default {

--- a/backend/src/middleware.ts
+++ b/backend/src/middleware.ts
@@ -57,9 +57,9 @@ export const verifyAuth = async (
   // Set here by previous middleware
   const tokenData = req.body.tokenData;
   try {
-    const user = await User.findOne(tokenData);
-    if (typeof user === "undefined")
-      return res.status(403).send("user doesn't exist");
+    const user = await User.findOne({ phone: tokenData });
+    console.log(user);
+    if (!user) return res.status(403).send("user doesn't exist");
     else {
       req.body.user = user;
       return next();


### PR DESCRIPTION
# Fixes verifyAuth

## Short description
The verify auth wasn't working because the check to see if the user was defined only rejected undefined user and not null users which was indeed what was returned by mangoose... That's fixed, as well as the user/self handler that now returns something using the expressJs return statement

## Done:

- [x] Add response statement
- [x] Make user is not existant test more sturdy